### PR TITLE
Issue #133: Pass in arbitrary options

### DIFF
--- a/scan.sh
+++ b/scan.sh
@@ -45,7 +45,7 @@ elif [ "$MODE" = "scan" ]; then
     echo ""
     echo -e "Scanning $SCANDIR"
     echo ""
-    clamscan -r $SCANDIR $@
+    clamscan -r $SCANDIR ${CLAMSCAN_OPTS:-} $@
     echo ""
     echo -e "$( date -I'seconds' ) ClamAV scanning finished"
 else


### PR DESCRIPTION
# Description

https://github.com/tquizzle/clamav-alpine/issues/133 points out that you can't pass in `--exclude` into the unraid template. This change should allow you to pass in _any_ clamav arguments.

**Note: This is yet to be tested!**

# Changes

* Expose a `CLAMSCAN_OPTS` to pass in arbitrary options to the container

You should be able to invoke it like this in Unraid's Docker template GUI. @tquizzle  will need to add a new environment variable field `CLAMSCAN_OPTS`:
```
Name: CLAMSCAN_OPTS
Value: --exclude=\.jpg$ --exclude=\.png$
```